### PR TITLE
Prevent duplicate technology names

### DIFF
--- a/src/main/java/com/example/technology/domain/usecase/CreateTechnologyUseCase.java
+++ b/src/main/java/com/example/technology/domain/usecase/CreateTechnologyUseCase.java
@@ -1,5 +1,7 @@
 package com.example.technology.domain.usecase;
 
+import com.example.technology.domain.error.DomainException;
+import com.example.technology.domain.error.ErrorCodes;
 import com.example.technology.domain.model.Technology;
 import com.example.technology.infrastructure.repository.SpringDataTechnologyRepository;
 import reactor.core.publisher.Mono;
@@ -9,6 +11,12 @@ public class CreateTechnologyUseCase {
   private final SpringDataTechnologyRepository repo;
   public CreateTechnologyUseCase(SpringDataTechnologyRepository repo) { this.repo = repo; }
   public Mono<Technology> execute(String name, String description) {
-    return repo.save(new Technology(UUID.randomUUID().toString(), name, description));
+    return repo.findByName(name)
+        .flatMap(existing -> Mono.<Technology>error(
+            new DomainException(ErrorCodes.CONFLICT, "technology.name.already.exists")
+        ))
+        .switchIfEmpty(Mono.defer(() ->
+            repo.save(new Technology(UUID.randomUUID().toString(), name, description))
+        ));
   }
 }

--- a/src/main/java/com/example/technology/infrastructure/repository/SpringDataTechnologyRepository.java
+++ b/src/main/java/com/example/technology/infrastructure/repository/SpringDataTechnologyRepository.java
@@ -24,6 +24,11 @@ public class SpringDataTechnologyRepository {
             .map(TechnologiesMapper::toDomain);
   }
 
+  public Mono<Technology> findByName(String name){
+    return template.selectOne(Query.query(Criteria.where("name").is(name)), TechnologyEntity.class)
+            .map(TechnologiesMapper::toDomain);
+  }
+
   public Mono<Technology> save(Technology franchise){
     var entity = TechnologiesMapper.toEntity(franchise);
     return template.insert(TechnologyEntity.class)

--- a/src/test/java/com/example/technology/domain/usecase/CreateTechnologyUseCaseTest.java
+++ b/src/test/java/com/example/technology/domain/usecase/CreateTechnologyUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.example.technology.domain.usecase;
 
+import com.example.technology.domain.error.DomainException;
 import com.example.technology.domain.model.Technology;
 import com.example.technology.domain.usecase.CreateTechnologyUseCase;
 import com.example.technology.infrastructure.repository.SpringDataTechnologyRepository;
@@ -14,6 +15,7 @@ class CreateTechnologyUseCaseTest {
   @Test
   void create_ok(){
     SpringDataTechnologyRepository repo = Mockito.mock(SpringDataTechnologyRepository.class);
+    Mockito.when(repo.findByName("My Franchise")).thenReturn(Mono.empty());
     Mockito.when(repo.save(Mockito.any(Technology.class))).thenAnswer(i -> Mono.just((Technology) i.getArguments()[0]));
     var uc = new CreateTechnologyUseCase(repo);
     StepVerifier.create(uc.execute("My Franchise", "des"))
@@ -22,5 +24,19 @@ class CreateTechnologyUseCaseTest {
           assertEquals("My Franchise", franchise.name());
         })
         .verifyComplete();
+  }
+
+  @Test
+  void create_conflict_when_name_exists(){
+    SpringDataTechnologyRepository repo = Mockito.mock(SpringDataTechnologyRepository.class);
+    Mockito.when(repo.findByName("My Franchise")).thenReturn(Mono.just(new Technology("id", "My Franchise", "des")));
+    var uc = new CreateTechnologyUseCase(repo);
+
+    StepVerifier.create(uc.execute("My Franchise", "des"))
+        .expectErrorSatisfies(error -> {
+          assertInstanceOf(DomainException.class, error);
+          assertEquals("technology.name.already.exists", error.getMessage());
+        })
+        .verify();
   }
 }

--- a/src/test/java/com/example/technology/infrastructure/repository/SpringDataTechnologyRepositoryTest.java
+++ b/src/test/java/com/example/technology/infrastructure/repository/SpringDataTechnologyRepositoryTest.java
@@ -13,10 +13,6 @@ import reactor.core.publisher.Mono;
 import static org.junit.jupiter.api.Assertions.*;
 
 class SpringDataTechnologyRepositoryTest {
-
-  private final R2dbcEntityTemplate template = Mockito.mock(R2dbcEntityTemplate.class);
-  private final SpringDataTechnologyRepository repository = new SpringDataTechnologyRepository(template);
-
   private static TechnologyEntity sampleEntity() {
     TechnologyEntity entity = new TechnologyEntity();
     entity.setId("f-1");
@@ -27,6 +23,8 @@ class SpringDataTechnologyRepositoryTest {
 
   @Test
   void findAllStreamsFromTemplate() {
+    R2dbcEntityTemplate template = Mockito.mock(R2dbcEntityTemplate.class);
+    SpringDataTechnologyRepository repository = new SpringDataTechnologyRepository(template);
     TechnologyEntity entity = sampleEntity();
     Mockito.when(template.select(Mockito.any(Query.class), Mockito.eq(TechnologyEntity.class)))
         .thenReturn(Flux.just(entity));
@@ -40,11 +38,28 @@ class SpringDataTechnologyRepositoryTest {
 
   @Test
   void findByIdUsesTemplate() {
+    R2dbcEntityTemplate template = Mockito.mock(R2dbcEntityTemplate.class);
+    SpringDataTechnologyRepository repository = new SpringDataTechnologyRepository(template);
     TechnologyEntity entity = sampleEntity();
     Mockito.when(template.selectOne(Mockito.any(Query.class), Mockito.eq(TechnologyEntity.class)))
         .thenReturn(Mono.just(entity));
 
     StepVerifier.create(repository.findById("f-1"))
+        .assertNext(franchise -> assertEquals("Acme", franchise.name()))
+        .verifyComplete();
+
+    Mockito.verify(template).selectOne(Mockito.any(Query.class), Mockito.eq(TechnologyEntity.class));
+  }
+
+  @Test
+  void findByNameUsesTemplate() {
+    R2dbcEntityTemplate template = Mockito.mock(R2dbcEntityTemplate.class);
+    SpringDataTechnologyRepository repository = new SpringDataTechnologyRepository(template);
+    TechnologyEntity entity = sampleEntity();
+    Mockito.when(template.selectOne(Mockito.any(Query.class), Mockito.eq(TechnologyEntity.class)))
+        .thenReturn(Mono.just(entity));
+
+    StepVerifier.create(repository.findByName("Acme"))
         .assertNext(franchise -> assertEquals("Acme", franchise.name()))
         .verifyComplete();
 


### PR DESCRIPTION
## Summary
- enforce a uniqueness check for technology names in the create use case
- add a repository lookup by name to support the conflict detection
- extend unit tests to cover the repository lookup and conflict scenario

## Testing
- ./gradlew test *(fails: Maven Central responded with 403 Forbidden when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f5c923e883208de633960e19864f